### PR TITLE
Disabling Unicode on Windows, fixes build

### DIFF
--- a/cmake/Modules/InitProject.cmake
+++ b/cmake/Modules/InitProject.cmake
@@ -9,7 +9,9 @@
 if (WIN32)
     # WIN32 will be set automatically
     add_definitions (-DWIN32)
-    add_definitions (-DUNICODE -D_UNICODE)
+
+    # currently on Windows this does not work because of std::string
+    #add_definitions (-DUNICODE -D_UNICODE)
 elseif (APPLE)
     add_definitions (-DMAC_OSX -DUNIX)
     set (MAC_OSX TRUE)


### PR DESCRIPTION
Fixing build on Windows.
- disabled UNICODE defintions for now in CMake. occurrences of std::string method `c_str()` caused compilation errors.
