### PR TITLE
Fixes copying of dependencies to destination folder, yasm is downloaded from github.

### DIFF
--- a/build_dependencies_mac.sh
+++ b/build_dependencies_mac.sh
@@ -58,10 +58,10 @@ if [ -e $INSTALL_DIR/bin/yasm ]; then
 else
     cd osx
     if [ -d yasm-1.2.0 ]; then
-     echo "Yasm already downloaded"
+        echo "Yasm already downloaded"
     else
-     curl -fL http://www.tortall.net/projects/yasm/releases/yasm-1.2.0.tar.gz > yasm-1.2.0.tar.gz
-     tar -xzf yasm-1.2.0.tar.gz
+        wget --no-check-certificate https://github.com/downloads/dozeo/screengrabber/yasm-1.2.0.tar.gz -O yasm-1.2.0.tar.gz
+        tar -xzf yasm-1.2.0.tar.gz
     fi
 
     echo "Compiling yasm"

--- a/build_dependencies_win.sh
+++ b/build_dependencies_win.sh
@@ -55,7 +55,8 @@ else
     if [ -d yasm-1.2.0 ]; then
         echo "Yasm already downloaded"
     else
-        curl -fL http://www.tortall.net/projects/yasm/releases/yasm-1.2.0.tar.gz > yasm-1.2.0.tar.gz
+        #curl -fL http://www.tortall.net/projects/yasm/releases/yasm-1.2.0.tar.gz > yasm-1.2.0.tar.gz
+        wget --no-check-certificate https://github.com/downloads/dozeo/screengrabber/yasm-1.2.0.tar.gz -O yasm-1.2.0.tar.gz
         tar -xzf yasm-1.2.0.tar.gz
     fi
     echo "Compiling yasm ..."

--- a/cmake/Modules/FindFFMPEG.cmake
+++ b/cmake/Modules/FindFFMPEG.cmake
@@ -75,7 +75,7 @@ if (FFMPEG_LIBAVFORMAT_FOUND AND FFMPEG_LIBAVCODEC_FOUND AND FFMPEG_LIBAVUTIL_FO
 			${FFMPEG_ROOT_DIR}/bin/avcodec-53.dll
 			${FFMPEG_ROOT_DIR}/bin/avutil-51.dll
 			${FFMPEG_ROOT_DIR}/bin/swscale-2.dll
-			${FFMPEG_ROOT_DIR}/bin/librtmp.dll
+			${FFMPEG_ROOT_DIR}/bin/librtmp-0.dll
 			${FFMPEG_ROOT_DIR}/bin/libz-1.dll
 			${FFMPEG_ROOT_DIR}/bin/libx264-125.dll
 #			${FFMPEG_ROOT_DIR}/bin/libeay32.dll


### PR DESCRIPTION
- the dependent libraries of the screencast application are copied to destination and install folders
- yasm assembler is downloaded from screengrabber repository now, its home location was offline
- includes minor fix in rtmpdump project
