### PR TITLE
Keyframe can be set in the VideoStream

### DIFF
--- a/libvideosend/videosend/VideoSender.h
+++ b/libvideosend/videosend/VideoSender.h
@@ -34,7 +34,7 @@ public:
 	static VideoSender* create (VideoSenderType type = VT_DEFAULT);
 
 	/// Usage: at first call setters and then init
-	virtual int setVideoSettings (int w, int h, float fps, int bitRate, enum VideoQualityLevel quality = VQ_MEDIUM) = 0;
+	virtual int setVideoSettings (int w, int h, float fps, int bitRate, int keyframe, enum VideoQualityLevel quality = VQ_MEDIUM) = 0;
 
 	/// Sets a target file
 	virtual int setTargetFile (const std::string & filename) = 0;

--- a/libvideosend/videosend/ffmpeg/VideoSenderFFmpeg.cpp
+++ b/libvideosend/videosend/ffmpeg/VideoSenderFFmpeg.cpp
@@ -8,6 +8,7 @@ VideoSenderFFmpeg::VideoSenderFFmpeg()
 : _frameSize(Dimension2(600, 400))
 , _fps(10)
 , _bitRate(300000)
+, _keyframe(10)
 , _videoStream(0)
 , _quality(VQ_MEDIUM)
 , _mode(OM_FILE)
@@ -21,11 +22,12 @@ VideoSenderFFmpeg::~VideoSenderFFmpeg()
 	uninitLog();
 }
 
-int VideoSenderFFmpeg::setVideoSettings(int w, int h, float fps, int bitRate, enum VideoQualityLevel quality)
+int VideoSenderFFmpeg::setVideoSettings(int w, int h, float fps, int bitRate, int keyframe, enum VideoQualityLevel quality)
 {
 	_frameSize = Dimension2(w, h);
 	_fps = fps;
 	_bitRate = bitRate;
+	_keyframe = keyframe;
 	_quality = quality;
 	return 0;
 }
@@ -52,11 +54,11 @@ int VideoSenderFFmpeg::open()
 	_videoStream = new VideoStream(_frameSize, CODEC_ID_H264);
 	if (_mode == OM_FILE)
 	{
-		result = _videoStream->openFile(_url, _fps, _bitRate, _quality);
+		result = _videoStream->openFile(_url, _fps, _bitRate, _keyframe, _quality);
 	}
 	else if (_mode == OM_URL)
 	{
-		result = _videoStream->openUrl(_url, _fps, _bitRate, _quality);
+		result = _videoStream->openUrl(_url, _fps, _bitRate, _keyframe, _quality);
 	}
 
 	return result;

--- a/libvideosend/videosend/ffmpeg/VideoSenderFFmpeg.h
+++ b/libvideosend/videosend/ffmpeg/VideoSenderFFmpeg.h
@@ -11,7 +11,7 @@ public:
 	VideoSenderFFmpeg();
 	virtual ~VideoSenderFFmpeg();
 
-	virtual int setVideoSettings(int w, int h, float fps, int bitRate, enum VideoQualityLevel quality);
+	virtual int setVideoSettings(int w, int h, float fps, int bitRate, int keyframe, enum VideoQualityLevel quality);
 	virtual int setTargetFile(const std::string & filename);
 	virtual int setTargetUrl(const std::string & url);
 	virtual int open();
@@ -38,6 +38,7 @@ private:
 	Dimension2   _frameSize;
 	float        _fps;
 	int          _bitRate;
+	int          _keyframe;
 	VideoQualityLevel _quality;
 	int          _defaultLogLevel;
 };

--- a/libvideosend/videosend/ffmpeg/VideoStream.h
+++ b/libvideosend/videosend/ffmpeg/VideoStream.h
@@ -17,8 +17,8 @@ public:
 	VideoStream(const Dimension2& videoSize, enum CodecID videoCodec);
 	virtual ~VideoStream();
 
-	int openUrl(const std::string& url, float frameRate, int bitRate, enum VideoQualityLevel level);
-	int openFile(const std::string& filename, float frameRate, int bitRate, enum VideoQualityLevel level);
+	int openUrl(const std::string& url, float frameRate, int bitRate, int keyframe, enum VideoQualityLevel level);
+	int openFile(const std::string& filename, float frameRate, int bitRate, int keyframe, enum VideoQualityLevel level);
 
 	void close();
 
@@ -32,12 +32,18 @@ private:
 		CM_RTP,
 	};
 
-	int open(const std::string& fileUrl, enum ConnectionMode mode, float frameRate, int bitRate, enum VideoQualityLevel level);
+	int open(
+		const std::string& fileUrl,
+		enum ConnectionMode mode,
+		float frameRate,
+		int bitRate,
+		int keyframe,
+		enum VideoQualityLevel level);
 
-	AVStream* addVideoStream(enum CodecID codecId, int bitRate, float fps, enum PixelFormat pixFormat, enum VideoQualityLevel level);
+	AVStream* addVideoStream(enum CodecID codecId, int bitRate, int keyframe, float fps, enum PixelFormat pixFormat, enum VideoQualityLevel level);
 	int openVideo(AVStream* stream);
 
-	void setBasicSettings(AVCodecContext* codec, int bitRate, float fps, enum CodecID codecId, enum PixelFormat pixFormat);
+	void setBasicSettings(AVCodecContext* codec, int bitRate, int keyframe, float fps, enum CodecID codecId, enum PixelFormat pixFormat);
 	void setVideoQualitySettings(AVCodecContext* codec, enum VideoQualityLevel level);
 
 	int setupScaleContext(const Dimension2& srcSize, const Dimension2& destSize);

--- a/libvideosend/videosend/null/NullVideoSender.cpp
+++ b/libvideosend/videosend/null/NullVideoSender.cpp
@@ -13,7 +13,7 @@ NullVideoSender::~NullVideoSender() {
 
 }
 
-int NullVideoSender::setVideoSettings (int w, int h, float fps, int bitRate, enum VideoQualityLevel quality) {
+int NullVideoSender::setVideoSettings (int w, int h, float fps, int bitRate, int keyframe, enum VideoQualityLevel quality) {
 	return 0;
 }
 

--- a/libvideosend/videosend/null/NullVideoSender.h
+++ b/libvideosend/videosend/null/NullVideoSender.h
@@ -8,7 +8,7 @@ public:
 	NullVideoSender ();
 	virtual ~NullVideoSender();
 	// Implementation
-	virtual int setVideoSettings (int w, int h, float fps, int bitRate, enum VideoQualityLevel quality);
+	virtual int setVideoSettings (int w, int h, float fps, int bitRate, int keyframe, enum VideoQualityLevel quality);
 	virtual int setTargetFile (const std::string & filename);
 	virtual int setTargetUrl (const std::string & url);
 	virtual int open ();

--- a/libvideosend/videosend/qt/QtVideoSender.cpp
+++ b/libvideosend/videosend/qt/QtVideoSender.cpp
@@ -13,24 +13,24 @@ void DrawingArea::paintEvent(QPaintEvent *) {
 
 QtVideoSender::QtVideoSender () {
 	mDrawingArea = 0;
-	mWidth   = 0;
-	mHeight  = 0;
-	mFps     = 0;
-	mBitRate = 0;
+	mWidth    = 0;
+	mHeight   = 0;
+	mFps      = 0;
+	mBitRate  = 0;
+	mKeyframe = 0;
 }
 
 QtVideoSender::~QtVideoSender () {
-
 }
 
-
-int QtVideoSender::setVideoSettings(int w, int h, float fps, int bitRate, enum VideoQualityLevel quality) {
+int QtVideoSender::setVideoSettings(int w, int h, float fps, int bitRate, int keyframe, enum VideoQualityLevel quality) {
 	assert (!mDrawingArea && "already started?");
 	if (w < 1 || h < 0 || fps < 0.1 || bitRate < 1) return VE_INVALID_RESOLUTION;
-	mWidth   = w;
-	mHeight  = h;
-	mFps     = fps;
-	mBitRate = bitRate;
+	mWidth    = w;
+	mHeight   = h;
+	mFps      = fps;
+	mKeyframe = keyframe;
+	mBitRate  = bitRate;
 	return 0;
 }
 

--- a/libvideosend/videosend/qt/QtVideoSender.h
+++ b/libvideosend/videosend/qt/QtVideoSender.h
@@ -20,7 +20,7 @@ public:
 	virtual ~QtVideoSender ();
 
 	// Implementation
-	virtual int setVideoSettings (int w, int h, float fps, int bitRate, enum VideoQualityLevel quality);
+	virtual int setVideoSettings (int w, int h, float fps, int bitRate, int keyframe, enum VideoQualityLevel quality);
 	virtual int setTargetFile (const std::string & filename);
 	virtual int setTargetUrl (const std::string & url);
 	virtual int open ();
@@ -32,6 +32,7 @@ private:
 	int  mWidth, mHeight;
 	float mFps;
 	int  mBitRate;
+	int mKeyframe;
 	std::string mTargetFile;
 	std::string mTargetUrl;
 


### PR DESCRIPTION
The keyframe property of the VideoStream setup can be given as parameter.
- keyframe property is part of the `VideoSenderOptions`, is set in video stream initialization
- code formating
