### PR TITLE
Build clean up, a destination folder for grabsend program can be set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,11 @@ cmake_minimum_required(VERSION 2.8)
 
 OPTION(OPTION_DISABLE_TESTS "Disable Test Projects" Off)
 
-# Additional tools
+# Set directories for the screengrabber folder and grabsend program
 set (SCREENGRABBER_DIRECTORY ${CMAKE_SOURCE_DIR})
+set (GRABSEND_INSTALL_DIRECTORY bin)
+
+# Additional tools
 set     (CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${SCREENGRABBER_DIRECTORY}/cmake/Modules/")
 include (Win32RelativeFolder)
 include (InitProject)

--- a/cmake/Modules/InitProject.cmake
+++ b/cmake/Modules/InitProject.cmake
@@ -106,9 +106,7 @@ if (Boost_FOUND)
 		# Boost for windows finds its libraries by itself.
 		list (APPEND SCREENGRAB_LIBS ${Boost_LIBRARIES})
 	endif()
-	if (Boost_FOUND)
-		link_directories (${Boost_LIBRARY_DIRS})
-	endif ()
+	link_directories (${Boost_LIBRARY_DIRS})
 endif()
 
 #

--- a/grabsend/CMakeLists.txt
+++ b/grabsend/CMakeLists.txt
@@ -16,7 +16,9 @@ target_link_libraries (grabsend ${SCREENGRAB_LIBS} grabber videosend ${FFMPEG_LI
 install (
     TARGETS grabsend
     BUNDLE DESTINATION . COMPONENT Runtime
-    RUNTIME DESTINATION bin COMPONENT Runtime)
+    RUNTIME DESTINATION ${GRABSEND_INSTALL_DIRECTORY} COMPONENT Runtime
+)
+
 if (WIN32)
     install (
         FILES ${FFMPEG_DLLS}


### PR DESCRIPTION
Cleans CMake build, it's possible to set an installation directory for grabsend program.
- fixes linking of boost directories
- an installation directory can be set for the `grabsend` program, defaults to `bin`
