### PR TITLE
Registering signal handler for system signals is done earlier

### DIFF
--- a/grabsend/src/main.cpp
+++ b/grabsend/src/main.cpp
@@ -25,6 +25,9 @@ namespace po = boost::program_options;
 /// Starts / Stop the video and does signal handling
 /// Note: grabbbingPipeline and sender must be completely initialized.
 int grabbingLoop (GrabbingPipeline * grabbingPipeline, const GrabSendOptions & options, dz::VideoSender * sender) {
+	installSigHandler ();
+	installLineReader ();
+
 	int result = sender->open();
 	if (result) {
 		std::cerr << "Error: Could not open output stream " << result << std::endl;
@@ -32,8 +35,6 @@ int grabbingLoop (GrabbingPipeline * grabbingPipeline, const GrabSendOptions & o
 	}
 	double t0 = microtime();
 	double timeToGrabSum = 0;
-	installSigHandler ();
-	installLineReader ();
 	int frame = 0;
 	while (!shutDownLoop()) {
 		double t1 = microtime();


### PR DESCRIPTION
Before grabber / videosender is opened first the signal handlers are registered. This allows
better error handling if the VideoSender hangs, which can happen if the URL is not
accessible.
