### PR TITLE
Fix download of pkg config lite on Windows

### DIFF
--- a/build_dependencies_win.sh
+++ b/build_dependencies_win.sh
@@ -116,8 +116,9 @@ else
     pkg_url=http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/pkg-config_0.26-1_win32.zip
     wget $pkg_url -O $pkg_filename
     $INSTALL_DIR/bin/unzip $pkg_filename
-    cp -rf pkg-config_0.26-1/* $INSTALL_DIR/
-    rm -r pkg-config_0.26-1
+    cp -rf bin/pkg-config.exe $INSTALL_DIR/
+    rm -r bin/pkg-config.exe
+    rm -r manifest/*
     rm $pkg_filename
     cd ..
 fi

--- a/build_dependencies_win.sh
+++ b/build_dependencies_win.sh
@@ -112,12 +112,12 @@ else
     echo "Fetching pkgconfig"
     cd win32
 
-    pkg_filename=pkg-config_0.26-1_win32.zip
-    pkg_url=http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/pkg-config_0.26-1_win32.zip
+    pkg_filename=pkg-config_0.28-1_bin-win32.zip
+    pkg_url=http://kent.dl.sourceforge.net/project/pkgconfiglite/0.28-1/pkg-config-lite-0.28-1_bin-win32.zip
     wget $pkg_url -O $pkg_filename
-    $INSTALL_DIR/bin/unzip $pkg_filename
-    cp -rf pkg-config_0.26-1/* $INSTALL_DIR/
-    rm -r pkg-config_0.26-1
+    $INSTALL_DIR/bin/unzip -o $pkg_filename
+    cp -rf pkg-config-lite-0.28-1/* $INSTALL_DIR/
+    rm -r pkg-config-lite-0.28-1
     rm $pkg_filename
     cd ..
 fi

--- a/build_dependencies_win.sh
+++ b/build_dependencies_win.sh
@@ -111,11 +111,14 @@ if [ -e $INSTALL_DIR/bin/pkg-config.exe ]; then
 else
     echo "Fetching pkgconfig"
     cd win32
-    wget http://downloads.sourceforge.net/project/pkgconfiglite/0.28-1/pkg-config-lite-0.28-1_bin-win32.zip?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fpkgconfiglite%2F&ts=1368656245&use_mirror=surfnet -O pkg-config-lite.zip
-    $INSTALL_DIR/bin/unzip pkg-config-lite.zip
-    cp -rf pkg-config-lite-0.28-1/* $INSTALL_DIR/
-    rm -r pkg-config-lite-0.28-1
-    rm pkg-config-lite.zip
+
+    pkg_filename=pkg-config_0.26-1_win32.zip
+    pkg_url=http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/pkg-config_0.26-1_win32.zip
+    wget $pkg_url -O $pkg_filename
+    $INSTALL_DIR/bin/unzip $pkg_filename
+    cp -rf pkg-config_0.26-1/* $INSTALL_DIR/
+    rm -r pkg-config_0.26-1
+    rm $pkg_filename
     cd ..
 fi
 

--- a/build_dependencies_win.sh
+++ b/build_dependencies_win.sh
@@ -111,11 +111,11 @@ if [ -e $INSTALL_DIR/bin/pkg-config.exe ]; then
 else
     echo "Fetching pkgconfig"
     cd win32
-    wget http://sflx.net/files/pkg-config-lite/pkg-config-lite-0.26-1_bin-win32.zip -O pkg-config-lite-0.26-1_bin-win32.zip
-    $INSTALL_DIR/bin/unzip pkg-config-lite-0.26-1_bin-win32.zip
-    cp -rf pkg-config-lite-0.26-1/* $INSTALL_DIR/
-    rm -r pkg-config-lite-0.26-1
-    rm pkg-config-lite-0.26-1_bin-win32.zip
+    wget http://downloads.sourceforge.net/project/pkgconfiglite/0.28-1/pkg-config-lite-0.28-1_bin-win32.zip?r=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fpkgconfiglite%2F&ts=1368656245&use_mirror=surfnet -O pkg-config-lite.zip
+    $INSTALL_DIR/bin/unzip pkg-config-lite.zip
+    cp -rf pkg-config-lite-0.28-1/* $INSTALL_DIR/
+    rm -r pkg-config-lite-0.28-1
+    rm pkg-config-lite.zip
     cd ..
 fi
 


### PR DESCRIPTION
On Windows the `pkg-config` executable is taken from a different source. It is used to build all dependencies.
