### PR TITLE
Fixes installation of grabsend executable

### DIFF
--- a/grabsend/CMakeLists.txt
+++ b/grabsend/CMakeLists.txt
@@ -16,7 +16,7 @@ target_link_libraries (grabsend ${SCREENGRAB_LIBS} grabber videosend ${FFMPEG_LI
 install (
     TARGETS grabsend
     BUNDLE DESTINATION . COMPONENT Runtime
-    RUNTIME DESTINATION ${GRABSEND_INSTALL_DIRECTORY} COMPONENT Runtime
+    RUNTIME DESTINATION bin COMPONENT Runtime
 )
 
 if (WIN32)


### PR DESCRIPTION
The deployment location of the grabsend executable got fixed. There was no warning or error message in building the screengrabber project. If a previous build contained grabsend in install dir, everything was fine.

Reverted to a previous state.
